### PR TITLE
fix: Change session driver to file to bypass database table issue

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -33,11 +33,11 @@ DB_USERNAME = "root"
 DB_PASSWORD = "ixOxZEOACaqQzVjzlFbnaDDeyMqErqRg"
 
 # Session & Cache
-SESSION_DRIVER = "database"
+SESSION_DRIVER = "file"
 SESSION_LIFETIME = "120"
 SESSION_ENCRYPT = "false"
-CACHE_STORE = "database"
-QUEUE_CONNECTION = "database"
+CACHE_STORE = "file"
+QUEUE_CONNECTION = "sync"
 
 # Logging (Debug enabled for troubleshooting)
 LOG_CHANNEL = "stack"


### PR DESCRIPTION
- Change SESSION_DRIVER from database to file
- Change CACHE_STORE from database to file
- Change QUEUE_CONNECTION from database to sync
- This allows app to start while we fix migration issues